### PR TITLE
Remove calls to deprecated CRM_Utils_Array::value

### DIFF
--- a/CRM/Campaigntools/Form/Settings.php
+++ b/CRM/Campaigntools/Form/Settings.php
@@ -77,7 +77,7 @@ class CRM_Campaigntools_Form_Settings extends CRM_Core_Form {
           default:
             $add = 'add' . $setting['quick_form_type'];
             if ($add == 'addElement') {
-              $this->$add($setting['html_type'], $name, E::ts($setting['title']), CRM_Utils_Array::value('html_attributes', $setting, array()));
+              $this->$add($setting['html_type'], $name, E::ts($setting['title']), $setting['html_attributes'] ?? []);
             }
             else {
               $this->$add($name, E::ts($setting['title']));
@@ -184,7 +184,7 @@ class CRM_Campaigntools_Form_Settings extends CRM_Core_Form {
   public function setDefaultValues() {
     $result = _campaigntools_civicrmapi('setting', 'get', array('return' => array_keys($this->_settings)));
     $domainID = CRM_Core_Config::domainID();
-    $ret = CRM_Utils_Array::value($domainID, $result['values']);
+    $ret = $result['values'][$domainID] ?? NULL;
     return $ret;
   }
 
@@ -193,7 +193,7 @@ class CRM_Campaigntools_Form_Settings extends CRM_Core_Form {
       return call_user_func($setting['X_options_callback']);
     }
     else {
-      return CRM_Utils_Array::value('X_options', $setting, array());
+      return $setting['X_options'] ?? [];
     }
   }
 


### PR DESCRIPTION
Replaces deprecated function with equivalent null-coalescing operator. Behavior should be the same before/after.